### PR TITLE
Improve placeholder images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ This contains everything you need to run your app locally.
    For image generation with the FLUX model, also set `HUGGINGFACE_API_KEY` to a Hugging Face token that has access to `black-forest-labs/FLUX.1-schnell`.
 3. Run the app:
    `npm run dev`
+
+### Placeholder images
+
+If AI image generation is disabled or fails, the app fetches placeholder images from the Unsplash Source API based on the keywords extracted from your narration.

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -25,23 +25,21 @@ const generateSceneKenBurnsConfig = (duration: number): KenBurnsConfig => {
 
 // Fetches a placeholder image URL based on keywords.
 export const fetchPlaceholderFootageUrl = (
-  keywords: string[], 
+  keywords: string[],
   aspectRatio: AspectRatio,
   sceneId?: string // Optional sceneId for more unique placeholders if needed
 ): string => {
   const width = aspectRatio === '16:9' ? 1280 : 720;
   const height = aspectRatio === '16:9' ? 720 : 1280;
-  
-  let seed = FALLBACK_FOOTAGE_KEYWORDS[Math.floor(Math.random() * FALLBACK_FOOTAGE_KEYWORDS.length)];
-  if (keywords && keywords.length > 0) {
-    seed = keywords.join('-').replace(/\s+/g, '-').toLowerCase();
-  }
-  // Adding sceneId to seed for more variety if multiple scenes have same keywords
-  if (sceneId) {
-    seed = `${seed}-${sceneId.substring(0,5)}`;
-  }
-  // Removed ?grayscale from the URL
-  return `https://picsum.photos/seed/${seed}/${width}/${height}?random_bust=${Date.now()}`; 
+
+  const keywordString = (keywords && keywords.length > 0
+    ? keywords.slice(0, 3).join(',')
+    : FALLBACK_FOOTAGE_KEYWORDS[Math.floor(Math.random() * FALLBACK_FOOTAGE_KEYWORDS.length)]
+  ).replace(/\s+/g, ',');
+
+  const cacheBuster = sceneId ? `&sig=${sceneId}` : `&t=${Date.now()}`;
+
+  return `https://source.unsplash.com/${width}x${height}/?${encodeURIComponent(keywordString)}${cacheBuster}`;
 };
 
 export interface ProcessNarrationOptions {


### PR DESCRIPTION
## Summary
- fetch placeholder images from Unsplash instead of random picsum photos
- document Unsplash fallback in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a93923fb4832e95d9a3398073ecb9