### PR TITLE
Add named figure image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ This contains everything you need to run your app locally.
 ### Placeholder images
 
 If AI image generation is disabled or fails, the app fetches placeholder images from the Unsplash Source API based on the keywords extracted from your narration.
+
+### Named figure images
+
+When your narration mentions well-known public figures such as **Elon Musk**,
+**Jeff Bezos**, or **Bernard Arnault**, the app automatically uses public domain
+or Creative Commons images from Wikimedia Commons instead of generic stock
+photos. Ensure their names appear in the extracted keywords to trigger this
+behavior.

--- a/constants.ts
+++ b/constants.ts
@@ -7,6 +7,18 @@ export const FALLBACK_FOOTAGE_KEYWORDS = [
   "abstract", "cityscape", "nature", "technology", "office", "landscape", "motion graphics"
 ];
 
+// Public domain or Creative Commons images for well-known figures.
+// These images are fetched instead of Unsplash placeholders when a scene's
+// keywords include the corresponding name.
+export const NAMED_FIGURE_IMAGE_URLS: Record<string, string> = {
+  "elon musk":
+    "https://upload.wikimedia.org/wikipedia/commons/3/34/Elon_Musk_Royal_Society_%28crop2%29.jpg",
+  "jeff bezos":
+    "https://upload.wikimedia.org/wikipedia/commons/0/0b/Jeff_Bezos_2016.jpg",
+  "bernard arnault":
+    "https://upload.wikimedia.org/wikipedia/commons/6/6d/Bernard_Arnault_2017.jpg",
+};
+
 // Gemini model for text analysis
 export const GEMINI_TEXT_MODEL = 'gemini-2.5-flash-preview-04-17';
 // Imagen model for image generation

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -1,6 +1,10 @@
 // Timestamp: 2024-09-12T10:00:00Z - Refresh
 import { Scene, GeminiSceneResponseItem, KenBurnsConfig, AspectRatio } from '../types.ts';
-import { FALLBACK_FOOTAGE_KEYWORDS, AVERAGE_WORDS_PER_SECOND } from '../constants.ts';
+import {
+  FALLBACK_FOOTAGE_KEYWORDS,
+  AVERAGE_WORDS_PER_SECOND,
+  NAMED_FIGURE_IMAGE_URLS,
+} from '../constants.ts';
 import { generateImageWithImagen } from './geminiService.ts';
 
 // Helper to generate Ken Burns configuration for a scene
@@ -31,6 +35,14 @@ export const fetchPlaceholderFootageUrl = (
 ): string => {
   const width = aspectRatio === '16:9' ? 1280 : 720;
   const height = aspectRatio === '16:9' ? 720 : 1280;
+
+  // Check if keywords mention a well-known figure with a predefined image.
+  const lowerKeywords = keywords.map(k => k.toLowerCase());
+  for (const [name, url] of Object.entries(NAMED_FIGURE_IMAGE_URLS)) {
+    if (lowerKeywords.some(k => k.includes(name))) {
+      return url;
+    }
+  }
 
   const keywordString = (keywords && keywords.length > 0
     ? keywords.slice(0, 3).join(',')


### PR DESCRIPTION
## Summary
- handle mentions of famous figures with Wikipedia images
- document use of public domain figure images

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a9a0a74fc832ea149112257c2c9e1